### PR TITLE
✨[feat] 모든 채팅 참여자에 대한 알림 기능 구현

### DIFF
--- a/src/main/java/com/MtoM/MtoM/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/MtoM/MtoM/domain/chat/controller/ChatController.java
@@ -1,6 +1,7 @@
 package com.MtoM.MtoM.domain.chat.controller;
 
 import com.MtoM.MtoM.domain.chat.domain.ChatMessage;
+import com.MtoM.MtoM.domain.chat.dto.ChatParticipantInfo;
 import com.MtoM.MtoM.domain.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,17 +38,8 @@ public class ChatController {
     }
 
     @GetMapping("/chat/notifications")
-    public Map<String, Object> getNotifications(@RequestParam String userId) {
-        List<ChatMessage> messages = chatMessageService.getMessagesForUser(userId);
-        ChatMessage lastMessage = chatMessageService.getLastMessageForUser(userId);
-        long unreadMessageCount = chatMessageService.countUnreadMessages(userId);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("unreadMessageCount", unreadMessageCount);
-        response.put("lastMessage", lastMessage != null ? lastMessage.getMessage() : null);
-        response.put("lastMessageTime", lastMessage != null ? lastMessage.getTimestamp() : null);
-        response.put("lastSenderId", lastMessage != null ? lastMessage.getSender().getId() : null);
-
-        return response;
+    public List<ChatParticipantInfo> getNotifications(@RequestParam String userId) {
+        return chatMessageService.getChatParticipantsInfo(userId);
     }
+
 }

--- a/src/main/java/com/MtoM/MtoM/domain/chat/dto/ChatParticipantInfo.java
+++ b/src/main/java/com/MtoM/MtoM/domain/chat/dto/ChatParticipantInfo.java
@@ -1,0 +1,14 @@
+package com.MtoM.MtoM.domain.chat.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ChatParticipantInfo {
+    private String userId;
+    private String lastMessage;
+    private long unreadMessageCount;
+    private LocalDateTime lastMessageTime;
+
+}

--- a/src/main/java/com/MtoM/MtoM/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/MtoM/MtoM/domain/chat/repository/ChatMessageRepository.java
@@ -3,12 +3,22 @@ package com.MtoM.MtoM.domain.chat.repository;
 import com.MtoM.MtoM.domain.chat.domain.ChatMessage;
 import com.MtoM.MtoM.domain.user.domain.UserDomain;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-    List<ChatMessage> findBySenderAndReceiver(UserDomain sender, UserDomain receiver);
-    List<ChatMessage> findByReceiver(UserDomain receiver);
-    ChatMessage findTopByReceiverOrderByTimestampDesc(UserDomain receiver);
-    List<ChatMessage> findByReceiverAndIsReadFalse(UserDomain receiver);
-}
+    public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+        List<ChatMessage> findBySenderAndReceiver(UserDomain sender, UserDomain receiver);
+        List<ChatMessage> findByReceiver(UserDomain receiver);
+        ChatMessage findTopByReceiverOrderByTimestampDesc(UserDomain receiver);
+        List<ChatMessage> findByReceiverAndIsReadFalse(UserDomain receiver);
+
+        @Query("SELECT DISTINCT c.sender FROM ChatMessage c WHERE c.receiver = :user " +
+                "UNION " +
+                "SELECT DISTINCT c.receiver FROM ChatMessage c WHERE c.sender = :user")
+        List<UserDomain> findChatPartners(@Param("user") UserDomain user);
+
+        ChatMessage findTopByReceiverOrSenderOrderByTimestampDesc(UserDomain receiver, UserDomain sender);
+        long countByReceiverAndSenderAndIsReadFalse(UserDomain receiver, UserDomain sender);
+    }


### PR DESCRIPTION
- 채팅 참여자 데이터를 캡슐화하기 위해 ChatParticipantInfo 클래스 추가
- ChatMessageService를 업데이트하여 채팅 참여자 정보 조회 및 처리
- 채팅 상대를 찾기 위해 ChatMessageRepository에 커스텀 쿼리 메서드 추가
- ChatController를 수정하여 채팅 참여자 알림 제공
- 각 채팅 참여자에 대해 마지막 메시지, 읽지 않은 메시지 수, 마지막 메시지 시간을 가져오는 로직 구현